### PR TITLE
Make use of Gravity Forms' currency functions.

### DIFF
--- a/coupons-for-gravityforms.php
+++ b/coupons-for-gravityforms.php
@@ -199,7 +199,8 @@ function sfn_gfcoupon_add_coupon_support($form){
 
                         var newPrice = ( total - discount );
                         jQuery( totalField ).val( newPrice );
-                        jQuery( '.ginput_total_'+formID ).html( '$'+newPrice );
+                        var currency = new Currency( gf_global.gf_currency_config );
+                        jQuery( '.ginput_total_'+formID ).html( currency.toMoney( newPrice ) );
 
                         couponApplied = true;
                     } else {


### PR DESCRIPTION
As per my issue https://github.com/curtismchale/Coupons-for-Gravity-Forms/issues/12
This changes make the plugin use the configured currency symbol and left or right placement.

I hope I did it right...

Mike
